### PR TITLE
Improve ESP-NOW communications with packet enums and send helper

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -14,6 +14,15 @@ extern esp_now_peer_info bot;
 extern bool sent_Status;
 extern bool receive_Status;
 
+// Packet index definitions used when packing telemetry.
+enum PacketIndex : byte
+{
+  PACK_TELEMETRY = 0,
+  PACK_LINE      = 1,
+  PACK_PID       = 2,
+  PACK_FIRE      = 3,
+};
+
 // Communication data structures shared with the controller.
 struct receptionDataPacket
 {
@@ -42,6 +51,10 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len);
 
 // Populate emission packet with telemetry.
 void packData(byte index);
+
+// Pack telemetry for the given index and transmit via ESP-NOW.
+// Returns true if the packet was queued for sending successfully.
+bool sendData(byte index);
 
 // Process received packets (stub).
 void processData(byte index);

--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -20,8 +20,11 @@ extern int operationMode;
 
 void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status)
 {
-  // Serial.print("\r\nLast Packet Send Status:\t");
-  // Serial.println(status == ESP_NOW_SEND_SUCCESS ? "Delivery Success" : "Delivery Fail");
+  sent_Status = (status == ESP_NOW_SEND_SUCCESS);
+  if(!sent_Status) {
+    // preserve the index of the packet that failed so it can be resent
+    resendIndex = emission.INDEX;
+  }
 }
 
 void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
@@ -33,46 +36,58 @@ void packData(byte index)
 {
   switch(index)
   {
-    case 0:
-    emission.INDEX = index;
-    emission.dataByte[0] = linePosition;
-    emission.dataByte[1] = front_distance;
-    emission.dataByte[2] = bot_distance;
-    emission.dataByte[3] = IRBias;
-    emission.dataByte[4] = average_count*Cm_per_Second_Conversion;
-    emission.dataByte[5] = batteryLevel;
-    emission.dataByte[6] = operationMode;
-    break;
+    case PACK_TELEMETRY:
+      emission.INDEX = index;
+      emission.dataByte[0] = linePosition;
+      emission.dataByte[1] = front_distance;
+      emission.dataByte[2] = bot_distance;
+      emission.dataByte[3] = IRBias;
+      emission.dataByte[4] = average_count*Cm_per_Second_Conversion;
+      emission.dataByte[5] = batteryLevel;
+      emission.dataByte[6] = operationMode;
+      break;
 
-    case 1:
-    emission.INDEX=index;
-    emission.dataByte[0] = sensor_readings[line_reading1];
-    emission.dataByte[1] = sensor_readings[line_reading2];
-    emission.dataByte[2] = sensor_readings[line_reading3];
-    emission.dataByte[3] = sensor_readings[line_reading4];
-    emission.dataByte[4] = lineThresholdsLowers[0];
-    emission.dataByte[5] = lineThresholdsLowers[1];
-    emission.dataByte[6] = lineThresholdsLowers[2];
-    emission.dataByte[7] = lineThresholdsLowers[3];
-    break;
+    case PACK_LINE:
+      emission.INDEX=index;
+      emission.dataByte[0] = sensor_readings[line_reading1];
+      emission.dataByte[1] = sensor_readings[line_reading2];
+      emission.dataByte[2] = sensor_readings[line_reading3];
+      emission.dataByte[3] = sensor_readings[line_reading4];
+      emission.dataByte[4] = lineThresholdsLowers[0];
+      emission.dataByte[5] = lineThresholdsLowers[1];
+      emission.dataByte[6] = lineThresholdsLowers[2];
+      emission.dataByte[7] = lineThresholdsLowers[3];
+      break;
 
-    case 2:
-    emission.INDEX= index;
-    emission.dataByte[0] = kp*100;
-    emission.dataByte[1] = kd*100;
-    emission.dataByte[3] = baseSpeed;
-    break;
+    case PACK_PID:
+      emission.INDEX= index;
+      emission.dataByte[0] = kp*100;
+      emission.dataByte[1] = kd*100;
+      emission.dataByte[3] = baseSpeed;
+      break;
 
-    case 3:
-    emission.INDEX= index;
-    emission.dataByte[0] = sensor_readings[fire_detection_left];
-    emission.dataByte[1] = sensor_readings[fire_detection_right];
-    emission.dataByte[3] = fireRange;
-    break;
+    case PACK_FIRE:
+      emission.INDEX= index;
+      emission.dataByte[0] = sensor_readings[fire_detection_left];
+      emission.dataByte[1] = sensor_readings[fire_detection_right];
+      emission.dataByte[3] = fireRange;
+      break;
 
     default:
     break;
   }
+}
+
+bool sendData(byte index)
+{
+  packData(index);
+  esp_err_t result = esp_now_send(targetAddress, (uint8_t *)&emission, sizeof(emission));
+  if(result != ESP_OK) {
+    resendIndex = emission.INDEX;
+    return false;
+  }
+  resendIndex = 0;
+  return true;
 }
 
 void processData(byte index)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,10 +289,5 @@ void loop() {
 
   // debug("\reception Speed: ")debug(reception.Speed);
   // debug("\reception MotionState: ")debug(String(reception.MotionState,BIN));
-  packData(0);
-
-  esp_err_t result = esp_now_send(targetAddress, (uint8_t *) &emission, sizeof(emission));
-  if (result == ESP_OK) {
-
-  }
+  sendData(PACK_TELEMETRY);
 }


### PR DESCRIPTION
## Summary
- define `PacketIndex` enum and `sendData` helper to streamline telemetry transmission
- track send status and failed packet index in `OnDataSent`
- update main loop to use new helper and packet definitions

## Testing
- `~/.local/bin/pio run`

------
https://chatgpt.com/codex/tasks/task_e_68c67d0c30fc832a9badc6171e9aa92a