### PR TITLE
Replace ESP-NOW handling with Dronegaze-style comms

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -6,8 +6,6 @@
 
 namespace Comms {
 
-constexpr uint32_t PACKET_MAGIC = 0xA1B2C3D4;
-
 struct ControlPacket {
     uint8_t Speed;
     uint8_t MotionState;
@@ -16,20 +14,18 @@ struct ControlPacket {
     bool bool1[4];
 } __attribute__((packed));
 
+enum PacketIndex : uint8_t {
+    PACK_TELEMETRY = 0,
+    PACK_LINE = 1,
+    PACK_PID = 2,
+    PACK_FIRE = 3,
+};
+
 struct TelemetryPacket {
-    uint32_t magic;
-    float pitch;
-    float roll;
-    float yaw;
-    float pitchCorrection;
-    float rollCorrection;
-    float yawCorrection;
-    uint16_t throttle;
-    int8_t pitchAngle;
-    int8_t rollAngle;
-    int8_t yawAngle;
-    float verticalAcc;
-    uint32_t commandAge;
+    uint8_t INDEX;
+    uint8_t statusByte;
+    int dataByte[8];
+    uint8_t okIndex;
 } __attribute__((packed));
 
 enum PairingType : uint8_t {
@@ -50,10 +46,17 @@ bool init(const char *ssid, const char *password, int tcpPort, esp_now_recv_cb_t
 
 bool receiveCommand(ControlPacket &cmd);
 bool paired();
+
+void packTelemetry(PacketIndex index, TelemetryPacket &packet);
 bool sendTelemetry(const TelemetryPacket &packet);
+bool sendTelemetry(PacketIndex index);
+
 uint32_t lastCommandTimeMs();
 const uint8_t *controllerMac();
+
 extern const uint8_t BroadcastMac[6];
+extern TelemetryPacket emission;
+extern uint8_t resendIndex;
 
 } // namespace Comms
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,6 @@ int operationMode;
 constexpr char WIFI_SSID[] = "Bulky Telemetry Port";
 constexpr char WIFI_PASSWORD[] = "";
 constexpr uint32_t COMMAND_TIMEOUT_MS = 500;
-constexpr float SPEED_TO_CM_PER_SEC = 10.362f;
 
 struct ControlState {
   byte motion;
@@ -338,28 +337,5 @@ void loop() {
     craneDeploy(controlState.cranePitch);
   }
 
-  Comms::TelemetryPacket packet{};
-  packet.magic = Comms::PACKET_MAGIC;
-  packet.pitch = static_cast<float>(linePosition);
-  packet.roll = static_cast<float>(front_distance);
-  packet.yaw = static_cast<float>(bot_distance);
-  packet.pitchCorrection = static_cast<float>(IRBias);
-  packet.rollCorrection = static_cast<float>(batteryLevel);
-  packet.yawCorrection = static_cast<float>(operationMode);
-  packet.throttle = static_cast<uint16_t>(controlState.speed);
-  packet.pitchAngle = static_cast<int8_t>(constrain(map(static_cast<long>(controlState.cameraPitch), 0L, 180L, -90L, 90L), -90L, 90L));
-  packet.rollAngle = static_cast<int8_t>(constrain(map(static_cast<long>(controlState.cameraYaw), 0L, 180L, -90L, 90L), -90L, 90L));
-  int8_t yawState = 0;
-  if(controlState.motion == ROTATE_RIGHT){
-    yawState = 45;
-  }else if(controlState.motion == ROTATE_LEFT){
-    yawState = -45;
-  }else if(controlState.motion == MOVE_BACK){
-    yawState = 90;
-  }
-  packet.yawAngle = yawState;
-  packet.verticalAcc = static_cast<float>(average_count * SPEED_TO_CM_PER_SEC);
-  uint32_t lastCommand = Comms::lastCommandTimeMs();
-  packet.commandAge = lastCommand ? (millis() - lastCommand) : 0;
-  Comms::sendTelemetry(packet);
+  Comms::sendTelemetry(Comms::PACK_TELEMETRY);
 }


### PR DESCRIPTION
## Summary
- replace the legacy ESP-NOW globals with a Dronegaze-style communications namespace that performs discovery using the Bulky identity and ILITE packet layouts
- translate incoming ThrustCommand packets into the robot control state and emit telemetry through the new TelemetryPacket structure
- initialise the new communications stack during setup and drop the direct WiFi/ESP-NOW handling from the main sketch

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd767166b4832a91ec4f5eec3ee16a