### PR TITLE
Improve ILITE pairing compatibility

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -33,6 +33,7 @@ enum PairingType : uint8_t {
     DRONE_IDENTITY = 0x02,
     ILITE_IDENTITY = 0x03,
     DRONE_ACK = 0x04,
+    ELITE_IDENTITY = 0x05,
 };
 
 struct IdentityMessage {


### PR DESCRIPTION
## Summary
- extend the pairing type enum with the ELITE identity constant used by ILITE controllers
- mirror Thegill's identity matching logic so Bulky recognises ILITE/ELITE strings, records the correct MAC, and replies with a fully populated acknowledgement
- harden controller MAC tracking so we update registered peers whenever the sender changes

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8b1dec64832ab469a0307ede7606