### PR TITLE
Add pairing beep cadence and fix discovery response

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -115,6 +115,7 @@ namespace {
         if (mac == nullptr) {
             return;
         }
+        ensurePeerRegistered(mac);
         IdentityMessage resp{};
         resp.type = DRONE_IDENTITY;
         strncpy(resp.identity, "Bulky", sizeof(resp.identity) - 1);


### PR DESCRIPTION
## Summary
- add a periodic pairing tone so Bulky beeps while awaiting a controller link
- register new ESP-NOW peers before replying to discovery so ILITE can see Bulky's MAC address

## Testing
- ❌ `pio run` (command not found in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce9b6c4a34832a8cde280007972f3f