### PR TITLE
Add ILITE broadcast feedback tone

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -55,6 +55,7 @@ bool sendTelemetry(PacketIndex index);
 uint32_t lastCommandTimeMs();
 uint32_t lastPairingAckTimeMs();
 const uint8_t *controllerMac();
+uint32_t lastIliteBroadcastTimeMs();
 
 extern const uint8_t BroadcastMac[6];
 extern TelemetryPacket emission;


### PR DESCRIPTION
## Summary
- capture ILITE broadcast identity messages and reply with the drone identity
- expose the latest ILITE broadcast timestamp for the main loop to consume
- add a distinct buzzer tone when an ILITE broadcast is received

## Testing
- ⚠️ `pio run` *(pio not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9f05d498832aadf6259a323d7f22