### PR TITLE
Fix ESP-NOW pairing by using AP interface MAC

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -2,6 +2,7 @@
 
 #include <ctype.h>
 #include <cstring>
+#include <esp_wifi.h>
 
 namespace Comms {
 namespace {
@@ -75,7 +76,7 @@ void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
             IdentityMessage resp{};
             resp.type = DRONE_IDENTITY;
             strncpy(resp.identity, "THEGILL", sizeof(resp.identity));
-            WiFi.macAddress(resp.mac);
+            WiFi.softAPmacAddress(resp.mac);
             esp_now_send(mac, reinterpret_cast<const uint8_t *>(&resp), sizeof(resp));
             return;
         }
@@ -86,6 +87,7 @@ void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
                 memcpy(peerInfo.peer_addr, mac, 6);
                 peerInfo.channel = 0;
                 peerInfo.encrypt = false;
+                peerInfo.ifidx = WIFI_IF_AP;
                 esp_now_add_peer(&peerInfo);
             }
             IdentityMessage ack{};
@@ -121,6 +123,7 @@ bool initInternal(const char *ssid, const char *password, int tcpPort, esp_now_r
     memcpy(peerInfo.peer_addr, BroadcastMac, 6);
     peerInfo.channel = 0;
     peerInfo.encrypt = false;
+    peerInfo.ifidx = WIFI_IF_AP;
     if (!esp_now_is_peer_exist(BroadcastMac)) {
         esp_now_add_peer(&peerInfo);
     }


### PR DESCRIPTION
## Summary
- ensure ESP-NOW peers are registered on the softAP interface
- respond to scan requests with the access point MAC address
- include esp_wifi header for WIFI_IF_AP constant

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68ceda3a91e4832a8ac686a9afc7c61c