### PR TITLE
Fix LEDC setup for buzzer channel

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -334,7 +334,7 @@ void setup() {
   //PWM drive defs
   ledcSetup(0,140,12); //pmp
   ledcSetup(1,10000,12); //LED, resulotion of 4096, might change if need to
-  ledcSetup(2,20000,12);
+  ledcSetup(2,20000,11); // 12-bit resolution can't achieve 20kHz with 80MHz clock
 
 
   ledcAttachPin(Pump_Pin,0);


### PR DESCRIPTION
## Summary
- lower the LEDC resolution for the buzzer channel so that the requested 20 kHz frequency is achievable
- add a clarifying comment explaining the resolution change

## Testing
- Not run (platformio is not installed in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cef15abbb0832ab6258a1a955d645b