### PR TITLE
Handle ESP-NOW callback registration failures

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -4,8 +4,14 @@
 #include "motion.h"
 #include "sensors.h"
 
-#include <cstring>
 #include <cctype>
+#include <cstring>
+
+#if defined(ESP_PLATFORM)
+#include <esp_idf_version.h>
+#endif
+
+#include <esp_err.h>
 
 extern int operationMode;
 
@@ -32,6 +38,7 @@ namespace {
     uint32_t g_lastPairingAckTime = 0;
     uint32_t g_lastIliteBroadcastTime = 0;
     bool g_espNowInitialised = false;
+    esp_now_recv_cb_t g_externalRecvCallback = nullptr;
 
     bool isBroadcastMac(const uint8_t *mac) {
         if (mac == nullptr) {
@@ -209,13 +216,17 @@ namespace {
         g_paired = true;
     }
 
-    void onDataRecvInternal(const uint8_t *mac, const uint8_t *incomingData, int len) {
+    void IRAM_ATTR onDataRecvInternal(const uint8_t *mac, const uint8_t *incomingData, int len) {
         ledcWriteTone(2,380);
         delay(10);
         Serial.println("Recieved something");
         delay(10);
         if (mac == nullptr || incomingData == nullptr) {
             return;
+        }
+
+        if (g_externalRecvCallback) {
+            g_externalRecvCallback(mac, incomingData, len);
         }
         if (len == static_cast<int>(sizeof(IdentityMessage))) {
             const IdentityMessage *msg = reinterpret_cast<const IdentityMessage *>(incomingData);
@@ -272,6 +283,23 @@ namespace {
         }
     }
 
+#if defined(ESP_IDF_VERSION) && defined(ESP_IDF_VERSION_VAL)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
+    void IRAM_ATTR onEspNowDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, int len) {
+        const uint8_t *mac = info ? info->src_addr : nullptr;
+        onDataRecvInternal(mac, incomingData, len);
+    }
+#else
+    void IRAM_ATTR onEspNowDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
+        onDataRecvInternal(mac, incomingData, len);
+    }
+#endif
+#else
+    void IRAM_ATTR onEspNowDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
+        onDataRecvInternal(mac, incomingData, len);
+    }
+#endif
+
     bool initInternal(const char *ssid, const char *password, int tcpPort, esp_now_recv_cb_t recvCallback) {
         (void)tcpPort;
         Serial.println("Initialising Comms");
@@ -284,7 +312,18 @@ namespace {
         WiFi.setTxPower(WIFI_POWER_19_5dBm);
             delay(100);
 
-        esp_now_init();
+        if (g_espNowInitialised) {
+            esp_now_register_recv_cb(nullptr);
+            esp_now_deinit();
+            g_espNowInitialised = false;
+            delay(10);
+        }
+
+        esp_err_t initResult = esp_now_init();
+        if (initResult != ESP_OK) {
+            Serial.printf("ESP-NOW init failed: %s (%d)\n", esp_err_to_name(initResult), static_cast<int>(initResult));
+            return false;
+        }
         delay(10);
         g_espNowInitialised = true;
 
@@ -296,7 +335,14 @@ namespace {
             esp_now_add_peer(&peerInfo);
         }
 
-        esp_now_register_recv_cb(&onDataRecvInternal);
+        g_externalRecvCallback = recvCallback;
+        esp_err_t registerResult = esp_now_register_recv_cb(&onEspNowDataRecv);
+        if (registerResult != ESP_OK) {
+            Serial.printf("Failed to register ESP-NOW recv callback: %s (%d)\n", esp_err_to_name(registerResult), static_cast<int>(registerResult));
+            esp_now_deinit();
+            g_espNowInitialised = false;
+            return false;
+        }
         delay(10);
         g_paired = false;
         memset(g_controllerMac, 0, sizeof(g_controllerMac));


### PR DESCRIPTION
## Summary
- add platform guard to translate ESP-NOW receive callbacks from the esp-now info structure to the legacy MAC-based handler
- harden ESP-NOW initialisation by reinitialising when already set up and surfacing init/register failures with diagnostics
- mark receive handlers IRAM_ATTR so they can safely execute from the WiFi context

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cefa0dfdb8832a85e2dd41008ada54