### PR TITLE
Support ILITE ESP-NOW discovery

### DIFF
--- a/include/EspNowDiscovery.h
+++ b/include/EspNowDiscovery.h
@@ -38,6 +38,7 @@ class EspNowDiscovery {
   void sendIliteIdentity(const std::array<uint8_t, 6> &mac, const String &droneName);
 
   bool ensurePeer(const std::array<uint8_t, 6> &mac);
+  bool handleIliteMessage(const uint8_t *mac, const uint8_t *data, int len);
 
   Comm::PeerRegistry &registry_;
   std::array<uint8_t, 6> controllerMac_{};


### PR DESCRIPTION
## Summary
- add support for ILITE-style ESP-NOW discovery and acknowledgement packets
- broadcast ILITE discovery frames and identity responses alongside existing protocol

## Testing
- platformio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1718e738832a97aacbefa140690d