### PR TITLE
Refactor control loop with FreeRTOS tasks and boost WiFi power

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -23,5 +23,6 @@ extern ControlState controlState;
 
 void resetControlState();
 void updateControlFromComms();
-void updateBuzzerOutput();
+ControlState getControlStateSnapshot();
+void updateBuzzerOutput(const ControlState &state);
 void action();

--- a/src/EspNowDiscovery.cpp
+++ b/src/EspNowDiscovery.cpp
@@ -63,6 +63,14 @@ bool EspNowDiscovery::begin() {
   }
   WiFi.softAPsetHostname("Bulky");
 
+  esp_err_t txPowerResult = esp_wifi_set_max_tx_power(84);
+  if (txPowerResult != ESP_OK) {
+    Serial.print("[ESP-NOW] Failed to set max TX power: ");
+    Serial.println(txPowerResult);
+  } else if (!WiFi.setTxPower(WIFI_POWER_19_5dBm)) {
+    Serial.println("[ESP-NOW] Failed to set WiFi TX power level");
+  }
+
   WiFi.macAddress(localMac_.data());
   bool macValid = false;
   for (auto byte : localMac_) {


### PR DESCRIPTION
## Summary
- add FreeRTOS support with mutex-protected control state access and dedicated sensor, communications, actuator, and UI tasks to balance work across both ESP32 cores
- provide a snapshot helper and updated buzzer logic so peripherals operate on consistent control data without blocking
- raise the ESP-NOW transmit power to the maximum supported level for more reliable wireless links

## Testing
- `platformio run`


------
https://chatgpt.com/codex/tasks/task_e_68cfba49ab04832aab9421eafa6b2514