### PR TITLE
Implement ESP-NOW identity pairing workflow

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -4,41 +4,91 @@
 #include <esp_now.h>
 
 namespace Comms {
+
+enum class DeviceRole : uint8_t {
+    Controller = 0,
+    Controlled = 1,
+};
+
+#ifndef DEVICE_ROLE
+#define DEVICE_ROLE Comms::DeviceRole::Controlled
+#endif
+
+enum class MessageType : uint8_t {
+    MSG_PAIR_REQ = 0x01,
+    MSG_IDENTITY_REPLY = 0x02,
+    MSG_PAIR_CONFIRM = 0x03,
+    MSG_PAIR_ACK = 0x04,
+    MSG_KEEPALIVE = 0x05,
+};
+
+constexpr uint8_t PROTOCOL_VERSION = 1;
+constexpr uint8_t WIFI_CHANNEL = 1;
+constexpr uint32_t BROADCAST_INTERVAL_MS = 500;
+constexpr uint32_t DEVICE_TTL_MS = 5000;
+constexpr uint32_t LINK_TIMEOUT_MS = 3000;
+
+#pragma pack(push, 1)
+struct Identity {
+    char deviceType[12];
+    char platform[16];
+    char customId[32];
+    uint8_t mac[6];
+};
+
+struct Packet {
+    uint8_t version;
+    MessageType type;
+    Identity id;
+    uint32_t monotonicMs;
+    uint32_t reserved;
+};
+
 struct ControlPacket {
     uint8_t replyIndex;
     int8_t speed;
     uint8_t motionState;
     uint8_t buttonStates[3];
-} __attribute__((packed));
+};
+#pragma pack(pop)
 
-struct TelemetryPacket {
-  uint32_t magic;                // Should be PACKET_MAGIC
-  float pitch, roll, yaw;        // Orientation in degrees
-  float pitchCorrection, rollCorrection, yawCorrection; // PID outputs
-  uint16_t throttle;             // Current throttle command
-  int8_t pitchAngle, rollAngle, yawAngle; // Commanded angles
-  float altitude;                // Estimated altitude
-  float verticalAcc;             // Vertical acceleration in m/s^2
-  uint32_t commandAge;           // Age of last command in ms
-} __attribute__((packed));
-
-enum PairingType : uint8_t {
-    SCAN_REQUEST = 0x01,
-    DRONE_IDENTITY = 0x02,
-    ILITE_IDENTITY = 0x03,
-    DRONE_ACK = 0x04,
+struct DiscoveryInfo {
+    Identity identity;
+    uint32_t lastSeenMs;
 };
 
-struct IdentityMessage {
-    uint8_t type;
-    char identity[16];
-    uint8_t mac[6];
-} __attribute__((packed));
+struct LinkStatus {
+    bool paired = false;
+    Identity peerIdentity{};
+    uint8_t peerMac[6] = {0};
+    uint32_t lastActivityMs = 0;
+    uint32_t lastCommandMs = 0;
+};
+
+using TargetSelector = int (*)(const DiscoveryInfo *entries, size_t count);
+
+void setRole(DeviceRole role);
+DeviceRole getRole();
+void setPlatform(const char *platformName);
+void setCustomId(const char *customId);
+void setDeviceTypeOverride(const char *deviceTypeName);
+void setTargetSelector(TargetSelector selector);
+
+void fillSelfIdentity(Identity &outIdentity);
+String macToString(const uint8_t mac[6]);
+bool macEqual(const uint8_t lhs[6], const uint8_t rhs[6]);
+bool ensurePeer(const uint8_t mac[6]);
 
 bool init(const char *ssid, const char *password, int tcpPort);
 bool init(const char *ssid, const char *password, int tcpPort, esp_now_recv_cb_t recvCallback);
-bool receiveCommand(ControlPacket &cmd);
+void loop();
+
+bool receiveCommand(ControlPacket &cmd, uint32_t *timestampMs = nullptr);
+uint32_t lastCommandTimestamp();
+LinkStatus getLinkStatus();
 bool paired();
+
 extern const uint8_t BroadcastMac[6];
-}
+
+} // namespace Comms
 

--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -1,88 +1,531 @@
 #include "comms.h"
+
+#include <algorithm>
 #include <cstring>
+#include <cstdio>
+#include <vector>
+
+#include <esp_wifi.h>
+#include <freertos/FreeRTOS.h>
 
 namespace Comms {
-static bool g_paired = false;
-static ControlPacket lastCmd = {0};
-static uint8_t controllerMac[6] = {0};
-const uint8_t BroadcastMac[6] = {0xff,0xff,0xff,0xff,0xff,0xff};
+namespace {
 
-static void onDataRecv(const uint8_t* mac, const uint8_t* incomingData, int len) {
-    if (len == sizeof(IdentityMessage) && !g_paired) {
-        const IdentityMessage* msg = reinterpret_cast<const IdentityMessage*>(incomingData);
-        if (msg->type == SCAN_REQUEST) {
-            IdentityMessage resp{};
-            resp.type = DRONE_IDENTITY;
-            strncpy(resp.identity, "DRONEGAZE", sizeof(resp.identity));
-            WiFi.macAddress(resp.mac);
-            esp_now_send(mac, reinterpret_cast<const uint8_t*>(&resp), sizeof(resp));
-            return;
-        } else if (msg->type == ILITE_IDENTITY) {
-            memcpy(controllerMac, mac, 6);
-            if (!esp_now_is_peer_exist(mac)) {
-                esp_now_peer_info_t peerInfo{};
-                memcpy(peerInfo.peer_addr, mac, 6);
-                peerInfo.channel = 0;
-                peerInfo.encrypt = false;
-                esp_now_add_peer(&peerInfo);
-            }
-            IdentityMessage ack{};
-            ack.type = DRONE_ACK;
-            esp_now_send(mac, reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
-            g_paired = true;
-            return;
-        }
-    }
-    if (len == sizeof(ControlPacket)) {
-        const ControlPacket* cmd = reinterpret_cast<const ControlPacket*>(incomingData);
-        lastCmd = *cmd;
+const char *kDefaultControllerType = "controller";
+const char *kDefaultControlledType = "controlled";
+
+DeviceRole g_role = DEVICE_ROLE;
+char g_platform[sizeof(Identity::platform)] = "Bulky";
+char g_customId[sizeof(Identity::customId)] = "Bulky-A10";
+char g_deviceTypeOverride[sizeof(Identity::deviceType)] = "";
+bool g_hasDeviceTypeOverride = false;
+
+Identity g_selfIdentity{};
+Identity g_peerIdentity{};
+uint8_t g_peerMac[6] = {0};
+bool g_paired = false;
+bool g_waitingForAck = false;
+
+uint32_t g_lastPeerActivityMs = 0;
+uint32_t g_lastKeepaliveSentMs = 0;
+uint32_t g_lastBroadcastMs = 0;
+uint32_t g_lastConfirmMs = 0;
+
+std::vector<DiscoveryInfo> g_discovered;
+TargetSelector g_targetSelector = nullptr;
+
+ControlPacket g_lastCommand{};
+uint32_t g_lastCommandMs = 0;
+bool g_hasCommand = false;
+
+bool g_initialized = false;
+portMUX_TYPE g_mutex = portMUX_INITIALIZER_UNLOCKED;
+esp_now_recv_cb_t g_userRecvCallback = nullptr;
+
+const char *roleDeviceType(DeviceRole role) {
+    return role == DeviceRole::Controller ? kDefaultControllerType : kDefaultControlledType;
+}
+
+bool isBroadcast(const uint8_t mac[6]) {
+    static const uint8_t broadcast[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    return std::memcmp(mac, broadcast, 6) == 0;
+}
+
+void logPacket(const char *prefix, MessageType type, const uint8_t mac[6]) {
+    if (type == MessageType::MSG_KEEPALIVE) {
         return;
+    }
+    Serial.printf("[COMMS] %s type=%u to %s\n", prefix,
+                  static_cast<unsigned>(type), macToString(mac).c_str());
+}
+
+void resetLinkInternal(const char *reason) {
+    bool wasPaired = false;
+    uint8_t mac[6] = {0};
+    {
+        portENTER_CRITICAL(&g_mutex);
+        if (!reason) {
+            reason = "reset";
+        }
+        wasPaired = g_paired;
+        std::memcpy(mac, g_peerMac, sizeof(mac));
+        g_paired = false;
+        g_waitingForAck = false;
+        std::memset(g_peerMac, 0, sizeof(g_peerMac));
+        std::memset(&g_peerIdentity, 0, sizeof(g_peerIdentity));
+        g_lastPeerActivityMs = 0;
+        g_lastKeepaliveSentMs = 0;
+        g_lastConfirmMs = 0;
+        g_hasCommand = false;
+        g_lastCommandMs = 0;
+        portEXIT_CRITICAL(&g_mutex);
+    }
+    if (wasPaired && !isBroadcast(mac) && esp_now_is_peer_exist(mac)) {
+        esp_now_del_peer(mac);
+    }
+    Serial.printf("[COMMS] Link reset (%s)\n", reason);
+}
+
+void fillIdentityStrings(Identity &identity) {
+    std::memset(&identity, 0, sizeof(identity));
+    const char *deviceType = g_hasDeviceTypeOverride ? g_deviceTypeOverride : roleDeviceType(g_role);
+    std::snprintf(identity.deviceType, sizeof(identity.deviceType), "%s", deviceType);
+    std::snprintf(identity.platform, sizeof(identity.platform), "%s", g_platform);
+    std::snprintf(identity.customId, sizeof(identity.customId), "%s", g_customId);
+    WiFi.macAddress(identity.mac);
+}
+
+void updateSelfIdentity() {
+    fillIdentityStrings(g_selfIdentity);
+}
+
+Packet makePacket(MessageType type) {
+    Packet packet{};
+    packet.version = PROTOCOL_VERSION;
+    packet.type = type;
+    fillIdentityStrings(packet.id);
+    packet.monotonicMs = millis();
+    packet.reserved = 0;
+    return packet;
+}
+
+bool sendPacket(const uint8_t *mac, MessageType type) {
+    Packet packet = makePacket(type);
+    if (!isBroadcast(mac)) {
+        ensurePeer(mac);
+    }
+    esp_err_t err = esp_now_send(mac, reinterpret_cast<const uint8_t *>(&packet), sizeof(packet));
+    if (err != ESP_OK) {
+        Serial.printf("[COMMS] Failed to send packet type %u to %s (err=%d)\n",
+                      static_cast<unsigned>(type), macToString(mac).c_str(), err);
+        return false;
+    }
+    logPacket("Sent", type, mac);
+    return true;
+}
+
+void pruneDiscovery(uint32_t nowMs) {
+    portENTER_CRITICAL(&g_mutex);
+    auto endIt = std::remove_if(g_discovered.begin(), g_discovered.end(), [nowMs](const DiscoveryInfo &info) {
+        return nowMs - info.lastSeenMs > DEVICE_TTL_MS;
+    });
+    if (endIt != g_discovered.end()) {
+        g_discovered.erase(endIt, g_discovered.end());
+    }
+    portEXIT_CRITICAL(&g_mutex);
+}
+
+std::vector<DiscoveryInfo> discoverySnapshot() {
+    std::vector<DiscoveryInfo> snapshot;
+    portENTER_CRITICAL(&g_mutex);
+    snapshot = g_discovered;
+    portEXIT_CRITICAL(&g_mutex);
+    return snapshot;
+}
+
+void processPairRequest(const uint8_t *mac, const Packet &packet, uint32_t nowMs) {
+    if (g_role != DeviceRole::Controlled) {
+        return;
+    }
+    (void)packet;
+    ensurePeer(mac);
+    sendPacket(mac, MessageType::MSG_IDENTITY_REPLY);
+    portENTER_CRITICAL(&g_mutex);
+    g_lastPeerActivityMs = nowMs;
+    portEXIT_CRITICAL(&g_mutex);
+}
+
+void processIdentityReply(const uint8_t *mac, const Packet &packet, uint32_t nowMs) {
+    if (g_role != DeviceRole::Controller) {
+        return;
+    }
+    (void)mac;
+    DiscoveryInfo entry{};
+    entry.identity = packet.id;
+    entry.lastSeenMs = nowMs;
+
+    portENTER_CRITICAL(&g_mutex);
+    auto it = std::find_if(g_discovered.begin(), g_discovered.end(), [&](const DiscoveryInfo &existing) {
+        return macEqual(existing.identity.mac, packet.id.mac);
+    });
+    if (it != g_discovered.end()) {
+        *it = entry;
+    } else {
+        g_discovered.push_back(entry);
+        Serial.printf("[COMMS] Discovered %s (%s)\n", packet.id.customId, macToString(packet.id.mac).c_str());
+    }
+    portEXIT_CRITICAL(&g_mutex);
+}
+
+void processPairConfirm(const uint8_t *mac, const Packet &packet, uint32_t nowMs) {
+    if (g_role != DeviceRole::Controlled) {
+        return;
+    }
+    ensurePeer(mac);
+    {
+        portENTER_CRITICAL(&g_mutex);
+        g_peerIdentity = packet.id;
+        std::memcpy(g_peerMac, mac, sizeof(g_peerMac));
+        g_paired = true;
+        g_lastPeerActivityMs = nowMs;
+        g_lastKeepaliveSentMs = nowMs;
+        g_waitingForAck = false;
+        g_hasCommand = false;
+        g_lastCommandMs = 0;
+        portEXIT_CRITICAL(&g_mutex);
+    }
+    Serial.printf("[COMMS] Paired with controller %s\n", packet.id.customId);
+    sendPacket(mac, MessageType::MSG_PAIR_ACK);
+}
+
+void processPairAck(const uint8_t *mac, const Packet &packet, uint32_t nowMs) {
+    if (g_role != DeviceRole::Controller) {
+        return;
+    }
+    ensurePeer(mac);
+    {
+        portENTER_CRITICAL(&g_mutex);
+        g_peerIdentity = packet.id;
+        std::memcpy(g_peerMac, mac, sizeof(g_peerMac));
+        g_paired = true;
+        g_waitingForAck = false;
+        g_lastPeerActivityMs = nowMs;
+        g_lastKeepaliveSentMs = nowMs;
+        g_hasCommand = false;
+        g_lastCommandMs = 0;
+        portEXIT_CRITICAL(&g_mutex);
+    }
+    Serial.printf("[COMMS] Pair acknowledged by %s\n", packet.id.customId);
+}
+
+void processKeepalive(const uint8_t *mac, const Packet &packet, uint32_t nowMs) {
+    (void)packet;
+    if (!macEqual(mac, g_peerMac)) {
+        return;
+    }
+    portENTER_CRITICAL(&g_mutex);
+    g_lastPeerActivityMs = nowMs;
+    portEXIT_CRITICAL(&g_mutex);
+}
+
+void handlePacket(const uint8_t *mac, const Packet &packet, uint32_t nowMs) {
+    if (packet.version != PROTOCOL_VERSION) {
+        Serial.printf("[COMMS] Ignoring packet with mismatched version %u\n", packet.version);
+        return;
+    }
+    switch (packet.type) {
+    case MessageType::MSG_PAIR_REQ:
+        processPairRequest(mac, packet, nowMs);
+        break;
+    case MessageType::MSG_IDENTITY_REPLY:
+        processIdentityReply(mac, packet, nowMs);
+        break;
+    case MessageType::MSG_PAIR_CONFIRM:
+        processPairConfirm(mac, packet, nowMs);
+        break;
+    case MessageType::MSG_PAIR_ACK:
+        processPairAck(mac, packet, nowMs);
+        break;
+    case MessageType::MSG_KEEPALIVE:
+        processKeepalive(mac, packet, nowMs);
+        break;
     }
 }
 
-static bool initInternal(const char *ssid, const char *password, int tcpPort, esp_now_recv_cb_t recvCallback) {
-    (void)tcpPort;
-    // Run in AP+STA mode so ESP-NOW remains operational alongside SoftAP
-    WiFi.mode(WIFI_AP_STA);
-    WiFi.setTxPower(WIFI_POWER_19_5dBm);
-    WiFi.setSleep(false);
-    WiFi.softAP(ssid, password);
+void sendPairRequest(uint32_t nowMs) {
+    if (!g_initialized) {
+        return;
+    }
+    if (nowMs - g_lastBroadcastMs < BROADCAST_INTERVAL_MS) {
+        return;
+    }
+    g_lastBroadcastMs = nowMs;
+    sendPacket(BroadcastMac, MessageType::MSG_PAIR_REQ);
+}
 
-    if (esp_now_init() != ESP_OK) {
+void attemptPairing(uint32_t nowMs) {
+    if (g_role != DeviceRole::Controller) {
+        return;
+    }
+    if (g_paired) {
+        return;
+    }
+    if (g_waitingForAck) {
+        if (nowMs - g_lastConfirmMs > LINK_TIMEOUT_MS) {
+            Serial.println("[COMMS] Pair confirm timeout, retrying");
+            portENTER_CRITICAL(&g_mutex);
+            g_waitingForAck = false;
+            portEXIT_CRITICAL(&g_mutex);
+        }
+        return;
+    }
+    std::vector<DiscoveryInfo> snapshot = discoverySnapshot();
+    if (snapshot.empty()) {
+        return;
+    }
+    int targetIndex = 0;
+    if (g_targetSelector != nullptr) {
+        targetIndex = g_targetSelector(snapshot.data(), snapshot.size());
+        if (targetIndex < 0 || static_cast<size_t>(targetIndex) >= snapshot.size()) {
+            targetIndex = 0;
+        }
+    }
+    const Identity &targetIdentity = snapshot[static_cast<size_t>(targetIndex)].identity;
+    sendPacket(targetIdentity.mac, MessageType::MSG_PAIR_CONFIRM);
+    portENTER_CRITICAL(&g_mutex);
+    g_lastConfirmMs = nowMs;
+    g_waitingForAck = true;
+    portEXIT_CRITICAL(&g_mutex);
+}
+
+void maintainLink(uint32_t nowMs) {
+    if (!g_paired) {
+        return;
+    }
+    if (nowMs - g_lastKeepaliveSentMs >= BROADCAST_INTERVAL_MS) {
+        sendPacket(g_peerMac, MessageType::MSG_KEEPALIVE);
+        portENTER_CRITICAL(&g_mutex);
+        g_lastKeepaliveSentMs = nowMs;
+        portEXIT_CRITICAL(&g_mutex);
+    }
+    uint32_t lastActivity = 0;
+    {
+        portENTER_CRITICAL(&g_mutex);
+        lastActivity = g_lastPeerActivityMs;
+        portEXIT_CRITICAL(&g_mutex);
+    }
+    if (lastActivity != 0 && nowMs - lastActivity > LINK_TIMEOUT_MS) {
+        resetLinkInternal("timeout");
+    }
+}
+
+void onDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
+    uint32_t nowMs = millis();
+    if (len == static_cast<int>(sizeof(Packet))) {
+        Packet packet{};
+        std::memcpy(&packet, incomingData, sizeof(packet));
+        handlePacket(mac, packet, nowMs);
+    } else if (len == static_cast<int>(sizeof(ControlPacket))) {
+        if (macEqual(mac, g_peerMac)) {
+            portENTER_CRITICAL(&g_mutex);
+            std::memcpy(&g_lastCommand, incomingData, sizeof(ControlPacket));
+            g_lastCommandMs = nowMs;
+            g_hasCommand = true;
+            g_lastPeerActivityMs = nowMs;
+            portEXIT_CRITICAL(&g_mutex);
+        }
+    }
+    if (g_userRecvCallback != nullptr) {
+        g_userRecvCallback(mac, incomingData, len);
+    }
+}
+
+void onDataSent(const uint8_t *mac, esp_now_send_status_t status) {
+    (void)mac;
+    if (status != ESP_NOW_SEND_SUCCESS) {
+        Serial.printf("[COMMS] Send status: %d\n", status);
+    }
+}
+
+} // namespace
+
+const uint8_t BroadcastMac[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+void setRole(DeviceRole role) {
+    g_role = role;
+    updateSelfIdentity();
+}
+
+DeviceRole getRole() {
+    return g_role;
+}
+
+void setPlatform(const char *platformName) {
+    if (platformName == nullptr) {
+        platformName = "";
+    }
+    std::snprintf(g_platform, sizeof(g_platform), "%s", platformName);
+    updateSelfIdentity();
+}
+
+void setCustomId(const char *customId) {
+    if (customId == nullptr) {
+        customId = "";
+    }
+    std::snprintf(g_customId, sizeof(g_customId), "%s", customId);
+    updateSelfIdentity();
+}
+
+void setDeviceTypeOverride(const char *deviceTypeName) {
+    if (deviceTypeName == nullptr || deviceTypeName[0] == '\0') {
+        g_hasDeviceTypeOverride = false;
+        g_deviceTypeOverride[0] = '\0';
+    } else {
+        g_hasDeviceTypeOverride = true;
+        std::snprintf(g_deviceTypeOverride, sizeof(g_deviceTypeOverride), "%s", deviceTypeName);
+    }
+    updateSelfIdentity();
+}
+
+void setTargetSelector(TargetSelector selector) {
+    g_targetSelector = selector;
+}
+
+void fillSelfIdentity(Identity &outIdentity) {
+    fillIdentityStrings(outIdentity);
+}
+
+String macToString(const uint8_t mac[6]) {
+    char buffer[18];
+    std::snprintf(buffer, sizeof(buffer), "%02X:%02X:%02X:%02X:%02X:%02X",
+                  mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    return String(buffer);
+}
+
+bool macEqual(const uint8_t lhs[6], const uint8_t rhs[6]) {
+    return std::memcmp(lhs, rhs, 6) == 0;
+}
+
+bool ensurePeer(const uint8_t mac[6]) {
+    if (isBroadcast(mac)) {
+        if (!esp_now_is_peer_exist(mac)) {
+            esp_now_peer_info_t info{};
+            std::memcpy(info.peer_addr, mac, 6);
+            info.channel = WIFI_CHANNEL;
+            info.encrypt = false;
+            info.ifidx = WIFI_IF_STA;
+            return esp_now_add_peer(&info) == ESP_OK;
+        }
+        return true;
+    }
+    if (esp_now_is_peer_exist(mac)) {
+        return true;
+    }
+    esp_now_peer_info_t peer{};
+    std::memcpy(peer.peer_addr, mac, 6);
+    peer.channel = WIFI_CHANNEL;
+    peer.encrypt = false;
+    peer.ifidx = WIFI_IF_STA;
+    esp_err_t result = esp_now_add_peer(&peer);
+    if (result != ESP_OK) {
+        Serial.printf("[COMMS] Failed to add peer %s (err=%d)\n", macToString(mac).c_str(), result);
         return false;
     }
-
-    esp_now_peer_info_t peerInfo{};
-    memcpy(peerInfo.peer_addr, BroadcastMac, 6);
-    peerInfo.channel = 0;
-    peerInfo.encrypt = false;
-    if (!esp_now_is_peer_exist(BroadcastMac)) {
-        esp_now_add_peer(&peerInfo);
-    }
-
-    esp_now_register_recv_cb(recvCallback ? recvCallback : onDataRecv);
-
-    g_paired = false;
-    memset(controllerMac, 0, sizeof(controllerMac));
-    memset(&lastCmd, 0, sizeof(lastCmd));
     return true;
 }
 
 bool init(const char *ssid, const char *password, int tcpPort) {
-    return initInternal(ssid, password, tcpPort, nullptr);
+    return init(ssid, password, tcpPort, nullptr);
 }
 
 bool init(const char *ssid, const char *password, int tcpPort, esp_now_recv_cb_t recvCallback) {
-    return initInternal(ssid, password, tcpPort, recvCallback);
+    (void)tcpPort;
+    g_initialized = false;
+    WiFi.mode(WIFI_AP_STA);
+    WiFi.setSleep(false);
+    WiFi.softAP(ssid, password, WIFI_CHANNEL, false, 1);
+    esp_wifi_set_channel(WIFI_CHANNEL, WIFI_SECOND_CHAN_NONE);
+
+    if (esp_now_init() != ESP_OK) {
+        Serial.println("[COMMS] esp_now_init failed");
+        return false;
+    }
+
+    updateSelfIdentity();
+
+    g_userRecvCallback = recvCallback;
+    esp_now_register_recv_cb(onDataRecv);
+    esp_now_register_send_cb(onDataSent);
+
+    ensurePeer(BroadcastMac);
+
+    portENTER_CRITICAL(&g_mutex);
+    g_discovered.clear();
+    g_paired = false;
+    g_waitingForAck = false;
+    std::memset(&g_peerIdentity, 0, sizeof(g_peerIdentity));
+    std::memset(g_peerMac, 0, sizeof(g_peerMac));
+    g_lastBroadcastMs = millis() - BROADCAST_INTERVAL_MS;
+    g_lastKeepaliveSentMs = 0;
+    g_lastPeerActivityMs = 0;
+    g_lastConfirmMs = 0;
+    g_lastCommandMs = 0;
+    g_hasCommand = false;
+    portEXIT_CRITICAL(&g_mutex);
+
+    g_initialized = true;
+    Serial.printf("[COMMS] Initialized (%s mode)\n", roleDeviceType(g_role));
+    return true;
 }
 
-bool receiveCommand(ControlPacket &cmd) {
-    cmd = lastCmd;
-    return g_paired;
+void loop() {
+    if (!g_initialized) {
+        return;
+    }
+    uint32_t nowMs = millis();
+    pruneDiscovery(nowMs);
+    if (g_role == DeviceRole::Controller) {
+        sendPairRequest(nowMs);
+        attemptPairing(nowMs);
+    }
+    maintainLink(nowMs);
+}
+
+bool receiveCommand(ControlPacket &cmd, uint32_t *timestampMs) {
+    portENTER_CRITICAL(&g_mutex);
+    cmd = g_lastCommand;
+    if (timestampMs != nullptr) {
+        *timestampMs = g_lastCommandMs;
+    }
+    bool available = g_hasCommand && g_paired;
+    portEXIT_CRITICAL(&g_mutex);
+    return available;
+}
+
+uint32_t lastCommandTimestamp() {
+    portENTER_CRITICAL(&g_mutex);
+    uint32_t ts = g_lastCommandMs;
+    portEXIT_CRITICAL(&g_mutex);
+    return ts;
+}
+
+LinkStatus getLinkStatus() {
+    LinkStatus status;
+    portENTER_CRITICAL(&g_mutex);
+    status.paired = g_paired;
+    status.peerIdentity = g_peerIdentity;
+    std::memcpy(status.peerMac, g_peerMac, sizeof(status.peerMac));
+    status.lastActivityMs = g_lastPeerActivityMs;
+    status.lastCommandMs = g_lastCommandMs;
+    portEXIT_CRITICAL(&g_mutex);
+    return status;
 }
 
 bool paired() {
-    return g_paired;
-}
+    portENTER_CRITICAL(&g_mutex);
+    bool result = g_paired;
+    portEXIT_CRITICAL(&g_mutex);
+    return result;
 }
 
+} // namespace Comms

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,6 +171,55 @@ void drawStatusUi(uint32_t nowMs);
 const char *WIFI_SSID = "Bulky Telemetry";
 const char *WIFI_PASSWORD = "BulkyTelemetry";
 const int TCP_PORT = 8000;
+const char *DEVICE_PLATFORM = "Bulky";
+const char *DEVICE_CUSTOM_ID = "Bulky-A10";
+
+Comms::ControlPacket command = {0};
+
+struct LinkStateSnapshot {
+    bool paired = false;
+    Comms::Identity peerIdentity{};
+    uint8_t peerMac[6] = {0};
+    uint32_t lastActivityMs = 0;
+    uint32_t lastCommandTimeMs = 0;
+};
+
+static LinkStateSnapshot linkStateSnapshot{};
+
+static inline void storeLinkState(const Comms::LinkStatus &status)
+{
+    portENTER_CRITICAL(&commsStateMux);
+    linkStateSnapshot.paired = status.paired;
+    linkStateSnapshot.peerIdentity = status.peerIdentity;
+    memcpy(linkStateSnapshot.peerMac, status.peerMac, sizeof(linkStateSnapshot.peerMac));
+    linkStateSnapshot.lastActivityMs = status.lastActivityMs;
+    linkStateSnapshot.lastCommandTimeMs = status.lastCommandMs;
+    portEXIT_CRITICAL(&commsStateMux);
+}
+
+static inline LinkStateSnapshot loadLinkStateSnapshot()
+{
+    LinkStateSnapshot snapshot;
+    portENTER_CRITICAL(&commsStateMux);
+    snapshot = linkStateSnapshot;
+    portEXIT_CRITICAL(&commsStateMux);
+    return snapshot;
+}
+
+static inline void storeCommandSnapshot(const Comms::ControlPacket &value)
+{
+    portENTER_CRITICAL(&commandMux);
+    command = value;
+    portEXIT_CRITICAL(&commandMux);
+}
+
+static inline Comms::ControlPacket loadCommandSnapshot()
+{
+    portENTER_CRITICAL(&commandMux);
+    Comms::ControlPacket snapshot = command;
+    portEXIT_CRITICAL(&commandMux);
+    return snapshot;
+}
 
 void resetControlState()
 {
@@ -228,7 +277,7 @@ void drawStatusUi(uint32_t nowMs) {
 
   ControlState state = getControlStateSnapshot();
   LinkStateSnapshot link = loadLinkStateSnapshot();
-  bool paired = link.ilitePaired;
+  bool paired = link.paired;
   bool moving = state.speed > 0 && state.motion != STOP;
 
   u8g2.clearBuffer();
@@ -239,16 +288,18 @@ void drawStatusUi(uint32_t nowMs) {
 
   u8g2.setCursor(0, 22);
   if (paired) {
-    u8g2.print("Link: ILITE ");
-    auto printHexByte = [&](uint8_t value) {
-      if (value < 0x10) {
-        u8g2.print('0');
-      }
-      u8g2.print(value, HEX);
-    };
-    printHexByte(link.iliteMac[4]);
-    u8g2.print(':');
-    printHexByte(link.iliteMac[5]);
+    u8g2.print("Link: ");
+    if (link.peerIdentity.customId[0] != '\0') {
+      u8g2.print(link.peerIdentity.customId);
+    } else {
+      String macStr = Comms::macToString(link.peerMac);
+      u8g2.print(macStr.c_str());
+    }
+    if (link.peerIdentity.platform[0] != '\0') {
+      u8g2.print(" (");
+      u8g2.print(link.peerIdentity.platform);
+      u8g2.print(')');
+    }
   } else {
     u8g2.print("Link: Searching");
     if (((nowMs / 500) % 2) == 0) {
@@ -315,75 +366,6 @@ void action()
   }
 }
 
-const unsigned long HANDSHAKE_COOLDOWN = 500;
-const char *DRONE_ID = "Bulky";
-Comms::ControlPacket command = {0};
-static uint8_t iliteMac[6] = {0};
-uint8_t selfMac[6];
-static uint8_t commandPeer[6] = {0};
-static bool ilitePaired = false;
-static bool commandPeerSet = false;
-static uint32_t lastCommandTimeMs = 0;
-unsigned long lastDiscoveryTime = 0;
-
-struct LinkStateSnapshot {
-    bool ilitePaired = false;
-    bool commandPeerSet = false;
-    uint8_t iliteMac[6] = {0};
-    uint8_t commandPeer[6] = {0};
-    uint32_t lastCommandTimeMs = 0;
-};
-
-const unsigned long CONNECTION_TIMEOUT = 1000;
-
-static inline LinkStateSnapshot clearLinkState()
-{
-    LinkStateSnapshot previous;
-    portENTER_CRITICAL(&commsStateMux);
-    previous.ilitePaired = ilitePaired;
-    previous.commandPeerSet = commandPeerSet;
-    memcpy(previous.iliteMac, iliteMac, sizeof(iliteMac));
-    memcpy(previous.commandPeer, commandPeer, sizeof(commandPeer));
-    previous.lastCommandTimeMs = lastCommandTimeMs;
-    ilitePaired = false;
-    commandPeerSet = false;
-    memset(iliteMac, 0, sizeof(iliteMac));
-    memset(commandPeer, 0, sizeof(commandPeer));
-    lastCommandTimeMs = 0;
-    portEXIT_CRITICAL(&commsStateMux);
-    return previous;
-}
-
-static inline LinkStateSnapshot loadLinkStateSnapshot()
-{
-    LinkStateSnapshot snapshot;
-    portENTER_CRITICAL(&commsStateMux);
-    snapshot.ilitePaired = ilitePaired;
-    snapshot.commandPeerSet = commandPeerSet;
-    memcpy(snapshot.iliteMac, iliteMac, sizeof(iliteMac));
-    memcpy(snapshot.commandPeer, commandPeer, sizeof(commandPeer));
-    snapshot.lastCommandTimeMs = lastCommandTimeMs;
-    portEXIT_CRITICAL(&commsStateMux);
-    return snapshot;
-}
-
-void monitorConnection() {
-    LinkStateSnapshot state = loadLinkStateSnapshot();
-    if (!state.ilitePaired)
-        return;
-
-    uint32_t now = millis();
-    if (state.lastCommandTimeMs > 0 && now - state.lastCommandTimeMs > CONNECTION_TIMEOUT)
-    {
-        LinkStateSnapshot cleared = clearLinkState();
-        if (cleared.ilitePaired)
-        {
-            esp_now_del_peer(cleared.iliteMac);
-        }
-    }
-}
-
-
 void updateLinkAudioFeedback(uint32_t nowMs) {
   static bool wasPaired = false;
   static uint32_t lastPairingToneMs = 0;
@@ -391,7 +373,7 @@ void updateLinkAudioFeedback(uint32_t nowMs) {
   constexpr uint32_t kPairingToneIntervalMs = 2500;
 
   LinkStateSnapshot linkState = loadLinkStateSnapshot();
-  bool paired = linkState.ilitePaired;
+  bool paired = linkState.paired;
 
   if (paired) {
     if (!wasPaired) {
@@ -417,175 +399,23 @@ void updateLinkAudioFeedback(uint32_t nowMs) {
   }
 }
 
-
-static inline void storeCommandSnapshotFromISR(const Comms::ControlPacket &value)
-{
-    portENTER_CRITICAL_ISR(&commandMux);
-    command = value;
-    portEXIT_CRITICAL_ISR(&commandMux);
-}
-
-static inline void setLastCommandTimeMs(uint32_t value)
-{
-    portENTER_CRITICAL(&commsStateMux);
-    lastCommandTimeMs = value;
-    portEXIT_CRITICAL(&commsStateMux);
-}
-
-static inline void setLastCommandTimeMsFromISR(uint32_t value)
-{
-    portENTER_CRITICAL_ISR(&commsStateMux);
-    lastCommandTimeMs = value;
-    portEXIT_CRITICAL_ISR(&commsStateMux);
-}
-
-static inline void setIlitePeerFromISR(const uint8_t *mac)
-{
-    portENTER_CRITICAL_ISR(&commsStateMux);
-    memcpy(iliteMac, mac, sizeof(iliteMac));
-    ilitePaired = true;
-    portEXIT_CRITICAL_ISR(&commsStateMux);
-}
-
-static inline bool copyIliteMacFromISR(uint8_t dest[6])
-{
-    portENTER_CRITICAL_ISR(&commsStateMux);
-    bool paired = ilitePaired;
-    if (paired)
-    {
-        memcpy(dest, iliteMac, sizeof(iliteMac));
-    }
-    portEXIT_CRITICAL_ISR(&commsStateMux);
-    return paired;
-}
-
-static inline bool updateCommandPeerFromISR(const uint8_t *mac)
-{
-    portENTER_CRITICAL_ISR(&commsStateMux);
-    bool changed = !commandPeerSet || memcmp(commandPeer, mac, sizeof(commandPeer)) != 0;
-    if (changed)
-    {
-        memcpy(commandPeer, mac, sizeof(commandPeer));
-        commandPeerSet = true;
-    }
-    portEXIT_CRITICAL_ISR(&commsStateMux);
-    return changed;
-}
-
-static inline Comms::ControlPacket loadCommandSnapshot()
-{
-    portENTER_CRITICAL(&commandMux);
-    Comms::ControlPacket snapshot = command;
-    portEXIT_CRITICAL(&commandMux);
-    return snapshot;
-}
-
 void CommTask(void *pvParameters) {
     TickType_t lastWake = xTaskGetTickCount();
-    const TickType_t interval = pdMS_TO_TICKS(5);
+    const TickType_t interval = pdMS_TO_TICKS(20);
     while (true) {
+        Comms::loop();
 
-        monitorConnection();
-        LinkStateSnapshot state = loadLinkStateSnapshot();
-        if (!state.ilitePaired && millis() - lastDiscoveryTime > 1000) {
-            Comms::IdentityMessage msg = {};
-            msg.type = Comms::DRONE_IDENTITY;
-            strncpy(msg.identity, DRONE_ID, sizeof(msg.identity));
-            memcpy(msg.mac, selfMac, 6);
-            esp_now_send(Comms::BroadcastMac, (uint8_t *)&msg, sizeof(msg));
-            lastDiscoveryTime = millis();
-        }
-        vTaskDelayUntil(&lastWake, interval); // ~200 Hz for responsiveness
-    }
-}
-unsigned long lastHandshakeSent = 0;
-void onReceive(const uint8_t *mac, const uint8_t *incomingData, int len)
-{
-    if (len == sizeof(Comms::IdentityMessage))
-    {
-        Comms::IdentityMessage msg;
-        memcpy(&msg, incomingData, sizeof(msg));
-        unsigned long now = millis();
-        if (msg.type == Comms::SCAN_REQUEST)
-        {
-            if (now - lastHandshakeSent > HANDSHAKE_COOLDOWN)
-            {
-                if (!esp_now_is_peer_exist(mac))
-                {
-                    esp_now_peer_info_t peerInfo = {};
-                    memcpy(peerInfo.peer_addr, mac, 6);
-                    peerInfo.channel = 0;
-                    peerInfo.encrypt = false;
-                    esp_now_add_peer(&peerInfo);
-                }
-                Comms::IdentityMessage resp = {};
-                resp.type = Comms::DRONE_IDENTITY;
-                strncpy(resp.identity, DRONE_ID, sizeof(resp.identity));
-                memcpy(resp.mac, selfMac, 6);
-                esp_now_send(mac, (uint8_t *)&resp, sizeof(resp));
-                lastHandshakeSent = now;
-            }
+        Comms::LinkStatus status = Comms::getLinkStatus();
+        storeLinkState(status);
+
+        Comms::ControlPacket latest = {};
+        uint32_t commandTimestamp = 0;
+        bool hasCommand = Comms::receiveCommand(latest, &commandTimestamp);
+        if (hasCommand && status.paired) {
+            storeCommandSnapshot(latest);
         }
 
-
-        else if (msg.type == Comms::ILITE_IDENTITY)
-        {
-            uint8_t existingMac[6];
-            bool wasPaired = copyIliteMacFromISR(existingMac);
-            bool isNewPeer = !wasPaired || memcmp(existingMac, msg.mac, sizeof(existingMac)) != 0;
-            if (isNewPeer)
-            {
-                setIlitePeerFromISR(msg.mac);
-                updateCommandPeerFromISR(msg.mac);
-            }
-            esp_now_peer_info_t peerInfo = {};
-            memcpy(peerInfo.peer_addr, msg.mac, 6);
-            peerInfo.channel = 0;
-            peerInfo.encrypt = false;
-            if (!esp_now_is_peer_exist(msg.mac))
-            {
-                esp_now_add_peer(&peerInfo);
-            }
-            Comms::IdentityMessage ack = {};
-            ack.type = Comms::DRONE_ACK;
-            strncpy(ack.identity, DRONE_ID, sizeof(ack.identity));
-            memcpy(ack.mac, selfMac, 6);
-            esp_now_send(msg.mac, (uint8_t *)&ack, sizeof(ack));
-            lastHandshakeSent = now;
-        }
-
-        return;
-    }
-
-    if (len == sizeof(Comms::ControlPacket))
-    {
-        Comms::ControlPacket incoming;
-        memcpy(&incoming, incomingData, sizeof(incoming));
-
-        // Ignore commands from unknown devices
-        uint8_t pairedMac[6];
-        bool paired = copyIliteMacFromISR(pairedMac);
-        if (!paired || memcmp(mac, pairedMac, 6) != 0)
-        {
-            return;
-        }
-
-        storeCommandSnapshotFromISR(incoming);
-        uint32_t nowMs = xTaskGetTickCountFromISR() * portTICK_PERIOD_MS;
-        setLastCommandTimeMsFromISR(nowMs);
-
-        bool peerChanged = updateCommandPeerFromISR(mac);
-        if (peerChanged)
-        {
-            esp_now_peer_info_t peerInfo = {};
-            memcpy(peerInfo.peer_addr, mac, 6);
-            peerInfo.channel = 0;
-            peerInfo.encrypt = false;
-            if (!esp_now_is_peer_exist(mac))
-            {
-                esp_now_add_peer(&peerInfo);
-            }
-        }
+        vTaskDelayUntil(&lastWake, interval);
     }
 }
 
@@ -690,6 +520,9 @@ void setup() {
   u8g2.print("VDrop");
   u8g2.sendBuffer();
 
+  Comms::setPlatform(DEVICE_PLATFORM);
+  Comms::setCustomId(DEVICE_CUSTOM_ID);
+
   WiFi.disconnect(true);
   if (!Comms::init(WIFI_SSID, WIFI_PASSWORD, TCP_PORT)) {
     Serial.println("[COMMS] Failed to start echo listener");
@@ -700,6 +533,17 @@ void setup() {
   Serial.println(WIFI_SSID);
   Serial.print("[COMMS] SoftAP IP: ");
   Serial.println(WiFi.softAPIP());
+
+  Comms::Identity identity{};
+  Comms::fillSelfIdentity(identity);
+  Serial.print("[COMMS] Role: ");
+  Serial.println(identity.deviceType);
+  Serial.print("[COMMS] Platform: ");
+  Serial.println(identity.platform);
+  Serial.print("[COMMS] Custom ID: ");
+  Serial.println(identity.customId);
+  Serial.print("[COMMS] MAC: ");
+  Serial.println(Comms::macToString(identity.mac));
 
   ArduinoOTA.setHostname("Bulky");
   ArduinoOTA.onStart([]() {


### PR DESCRIPTION
## Summary
- replace legacy ESP-NOW handshake logic with a role-aware identity and pairing system
- add packed identity and protocol packet types plus discovery/keepalive management helpers
- refresh status UI and setup logging to surface peer identity details during operation

## Testing
- `pio run -e nodemcu-32s`


------
https://chatgpt.com/codex/tasks/task_e_68d327d550c0832aa3f0940ed85b3050