### PR TITLE
Remove keepalive packet handling

### DIFF
--- a/include/comms.h
+++ b/include/comms.h
@@ -19,7 +19,6 @@ enum class MessageType : uint8_t {
     MSG_IDENTITY_REPLY = 0x02,
     MSG_PAIR_CONFIRM = 0x03,
     MSG_PAIR_ACK = 0x04,
-    MSG_KEEPALIVE = 0x05,
 };
 
 constexpr uint8_t PROTOCOL_VERSION = 1;


### PR DESCRIPTION
## Summary
- remove the dedicated keepalive message type and associated packet handling logic
- rely on control traffic for link activity while pruning unused identity comparison helpers

## Testing
- pio run *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4180d378c832a960bf18fee691ae2