### PR TITLE
Stop broadcasting pairing requests once paired

### DIFF
--- a/src/comms.cpp
+++ b/src/comms.cpp
@@ -240,6 +240,9 @@ void sendPairRequest(uint32_t nowMs) {
     if (!g_initialized) {
         return;
     }
+    if (paired()) {
+        return;
+    }
     if (nowMs - g_lastBroadcastMs < BROADCAST_INTERVAL_MS) {
         return;
     }


### PR DESCRIPTION
## Summary
- skip sending broadcast pair requests when the link is already paired
- prevent connected devices from unnecessarily restarting the handshake protocol

## Testing
- `pio test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d423754350832a9d7ba41f03986369